### PR TITLE
Use minimum stability instead strict comparison

### DIFF
--- a/src/Command/StabilityOption.php
+++ b/src/Command/StabilityOption.php
@@ -16,6 +16,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/**
+ * @psalm-import-type StabilityType from Stability
+ */
 class StabilityOption extends Option
 {
     /**
@@ -46,6 +49,7 @@ class StabilityOption extends Option
 
     /**
      * {@inheritDoc}
+     * @return StabilityType|string
      */
     public function get(InputInterface $input, StyleInterface $io): string
     {

--- a/src/Environment/Stability.php
+++ b/src/Environment/Stability.php
@@ -42,6 +42,26 @@ final class Stability
     public const STABILITY_DEV = 'dev';
 
     /**
+     * @var int[]
+     */
+    private const WEIGHT = [
+        self::STABILITY_STABLE => 4,
+        self::STABILITY_RC     => 3,
+        self::STABILITY_BETA   => 2,
+        self::STABILITY_ALPHA  => 1,
+        self::STABILITY_DEV    => 0,
+    ];
+
+    /**
+     * @param StabilityType $type
+     * @return positive-int|0
+     */
+    public static function toInt(string $type): int
+    {
+        return self::WEIGHT[$type] ?? 0;
+    }
+
+    /**
      * @return array<string, StabilityType>
      */
     public static function all(): array

--- a/src/GetBinaryCommand.php
+++ b/src/GetBinaryCommand.php
@@ -254,7 +254,7 @@ class GetBinaryCommand extends Command
 
         /** @var ReleaseInterface[] $filtered */
         $filtered = $releases
-            ->stability($stabilityOption)
+            ->minimumStability($stabilityOption)
             ->withAssets()
         ;
 

--- a/src/VersionsCommand.php
+++ b/src/VersionsCommand.php
@@ -89,7 +89,7 @@ class VersionsCommand extends Command
         $versions = $this->getRepository()
             ->getReleases()
             ->sortByVersion()
-            ->stability($this->stability->get($input, $io))
+            ->minimumStability($this->stability->get($input, $io))
             ->filter(static fn(ReleaseInterface $release): bool => \count($release->getAssets()) > 0)
             ->satisfies($this->version->get($input, $io))
         ;


### PR DESCRIPTION
If a `--stability` flag is specified, it will now be used as the **minimum** value instead of strict comparison.

## Actual

Option `--stability=beta`
Indicates `beta` assembly

## Will Be

Option `--stability=beta`
Indicates `beta`, `RC` and `stable` assemblies
