### PR TITLE
Add aarch64 arm64 equivalent to architecture list [#9]

### DIFF
--- a/src/Environment/Architecture/Factory.php
+++ b/src/Environment/Architecture/Factory.php
@@ -37,6 +37,7 @@ class Factory
             'x64',
             'x86_64',
             'arm64',
+            'aarch64',
         ],
     ];
 


### PR DESCRIPTION
Add `aarch64` architecture which is supposed to be an `arm64` equivalent.
Tested via php8 alpine-based arm images which identify themselves as `aarch64`

Solves #9 