### PR TITLE
Stop asking to create config file if already exists in current dir

### DIFF
--- a/src/GetBinaryCommand.php
+++ b/src/GetBinaryCommand.php
@@ -202,7 +202,7 @@ class GetBinaryCommand extends Command
     {
         $to .= '/.rr.yaml';
 
-        if (\is_file($to)) {
+        if (\is_file($to) || \is_file(\getcwd().'/.rr.yaml')) {
             return false;
         }
 


### PR DESCRIPTION
Hi!

When specifying a target, if we already have a config in the current directory we do not want to generate a config aside the downloaded binary.
