### PR TITLE
Try to make binary executable after install

### DIFF
--- a/src/GetBinaryCommand.php
+++ b/src/GetBinaryCommand.php
@@ -186,6 +186,10 @@ class GetBinaryCommand extends Command
             $out->writeln($message);
 
             $extractor->next();
+
+            if (! $file->isExecutable()) {
+                @chmod($file->getRealPath(), 0755);
+            }
         }
 
         return $file;


### PR DESCRIPTION
Hi, after a first binary download, a `chmod +x rr` is required.

This PR try to make the downloaded binary executable.