### PR TITLE
Fix autodetect arch for apple m1 cpu

### DIFF
--- a/src/Environment/Architecture.php
+++ b/src/Environment/Architecture.php
@@ -23,6 +23,10 @@ final class Architecture
      * @var string
      */
     public const ARCH_X86_64 = 'amd64';
+    /**
+     * @var string
+     */
+    public const ARCH_ARM_64 = 'arm64';
 
     /**
      * @return ArchitectureType

--- a/src/Environment/Architecture/Factory.php
+++ b/src/Environment/Architecture/Factory.php
@@ -36,6 +36,8 @@ class Factory
             'x86',
             'x64',
             'x86_64',
+        ],
+        Architecture::ARCH_ARM_64 => [
             'arm64',
             'aarch64',
         ],

--- a/src/GetBinaryCommand.php
+++ b/src/GetBinaryCommand.php
@@ -119,6 +119,10 @@ class GetBinaryCommand extends Command
             ' Downloading...'
         );
 
+        if ($output->isVerbose()) {
+            $output->writeln(\sprintf("     -- <info>%s</info>", $asset->getName()));
+        }
+
         // Install rr binary
         $file = $this->installBinary($target, $release, $asset, $io, $output);
 


### PR DESCRIPTION
Current autodetect Environment on macbook pro with M1 cpu:
   - Version:          2.*
   - Stability:        stable
   - Operating System: darwin
   - Architecture:     amd64
 

After patch:
   - Version:          2.*
   - Stability:        stable
   - Operating System: darwin
   - Architecture:     arm64

