### PR TITLE
Bump required symfony component versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": ">=7.4",
         "ext-json": "*",
         "spiral/roadrunner-worker": ">=2.0.2",
-        "symfony/console": "^4.4|^5.0",
-        "symfony/http-client": "^4.4|^5.0",
+        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/http-client": "^4.4|^5.0|^6.0",
         "symfony/polyfill-php80": "^1.22",
         "composer/semver": "^3.2"
     },


### PR DESCRIPTION
Seems to work. At least I was able to run /vendor/bin/rr help,version,get in my project after replacing the repo in composer.json with my fork.

closes: #27 