### PR TITLE
Added new --no-config option to GetBinaryCommand, to skip generating config

### DIFF
--- a/src/GetBinaryCommand.php
+++ b/src/GetBinaryCommand.php
@@ -93,6 +93,13 @@ class GetBinaryCommand extends Command
             InputOption::VALUE_OPTIONAL,
             'Generate configuration with plugins in a selected preset.'
         );
+
+        $this->addOption(
+            'no-config',
+            null,
+            InputOption::VALUE_NONE,
+            'Do not generate configuration at all.'
+        );
     }
 
     /**
@@ -227,7 +234,7 @@ class GetBinaryCommand extends Command
             return false;
         }
 
-        if (! $io->confirm('Do you want create default ".rr.yaml" configuration file?', true)) {
+        if ($in->getOption('no-config') || ! $io->confirm('Do you want create default ".rr.yaml" configuration file?', true)) {
             return false;
         }
 


### PR DESCRIPTION
Closes #37 

This adds a new `--no-config` option to the GetBinaryCommand so that config generation can be skipped even in no-interactive mode.

Since it's a simple flag I have defined it inline, inside GetBinaryCommand, but I can switch it to a separated Option class as with `os`, `arch`, `version`, etc.