### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,14 @@
         "composer/semver": "^3.2",
         "spiral/roadrunner-worker": ">=2.0.2",
         "spiral/tokenizer": "^2.13 || ^3.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
-        "symfony/http-client": "^4.4|^5.0|^6.0",
+        "symfony/console": "^5.3 || ^6.0 || ^7.0",
+        "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.22",
-        "symfony/yaml": "^5.4 || ^6.0"
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "jetbrains/phpstorm-attributes": "^1.0",
-        "vimeo/psalm": "^4.4",
-        "symfony/var-dumper": "^4.4|^5.0"
+        "vimeo/psalm": "^5.17"
     },
     "scripts": {
         "analyze": "psalm"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "spiral/roadrunner-worker": ">=2.0.2",
         "spiral/tokenizer": "^2.13 || ^3.0",
         "symfony/console": "^5.3 || ^6.0 || ^7.0",
-        "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/http-client": "^4.4.11 || ^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.22",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
## What was changed

1. Support for Symfony 7.0 components has been added. 
2. The minimum version of **symfony/console** has been raised to 5.3, as **symfony/yaml** 5.4 has a conflict:
https://github.com/symfony/yaml/blob/v5.4.0/composer.json#L27
3. The dev dependency **vimeo/psalm** has been updated, as the old version did not support symfony/console 7.0. 
4. The minimum version of **symfony/http-client** has been raised to 4.4.11. See: https://github.com/symfony/symfony/pull/37379
5. The unused dev dependency **symfony/var-dumper** has been removed.