### PR TITLE
Support Symfony 8.0

### DIFF
--- a/bin/rr
+++ b/bin/rr
@@ -68,9 +68,17 @@ require RR_COMPOSER_INSTALL;
 
 $app = new Symfony\Component\Console\Application('RoadRunner CLI', Version::current());
 
-$app->add(new GetBinaryCommand());
-$app->add(new VersionsCommand());
-$app->add(new DownloadProtocBinaryCommand());
-$app->add(new MakeConfigCommand());
+if (method_exists($app, 'addCommand')) {
+    $app->addCommand(new GetBinaryCommand());
+    $app->addCommand(new VersionsCommand());
+    $app->addCommand(new DownloadProtocBinaryCommand());
+    $app->addCommand(new MakeConfigCommand());
+} else {
+    // For Symfony 7.3 and lower
+    $app->add(new GetBinaryCommand());
+    $app->add(new VersionsCommand());
+    $app->add(new DownloadProtocBinaryCommand());
+    $app->add(new MakeConfigCommand());
+}
 
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "composer/semver": "^3.4",
         "spiral/roadrunner-worker": "^2 || ^3",
         "spiral/tokenizer": "^2.13 || ^3.15",
-        "symfony/console": "^5.3 || ^6.0 || ^7.0",
-        "symfony/http-client": "^4.4.51 || ^5.4.49 || ^6.4.17 || ^7.2",
-        "symfony/yaml": "^5.4.49 || ^6.4.17 || ^7.2"
+        "symfony/console": "^5.3 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/http-client": "^4.4.51 || ^5.4.49 || ^6.4.17 || ^7.2 || ^8.0",
+        "symfony/yaml": "^5.4.49 || ^6.4.17 || ^7.2 || ^8.0"
     },
     "require-dev": {
         "jetbrains/phpstorm-attributes": "^1.2",


### PR DESCRIPTION
I verified the change logs, I could not find anything that could affect us. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded Symfony compatibility to include 8.x for console, HTTP client, and YAML components.
* **Chores**
  * Improved runtime handling of command registration to work across multiple Symfony versions, ensuring commands initialize correctly regardless of framework version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->